### PR TITLE
update dependencies

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,10 +18,11 @@ requirements:
   host:
     - python >=3.8
     - pip
-    - graph-tool >=2.40
+    - graph-tool-base >=2.40
   run:
     - python >=3.8 
-    - graph-tool >=2.40
+    - graph-tool-base >=2.40
+    - pycairo
     - scanpy
     - numpy
     - scipy

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,17 +11,17 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: "{{ PYTHON }} -m pip install . -vv --use-feature=in-tree-build"
 
 requirements:
   host:
     - python >=3.8
     - pip
-    - graph-tool-base >=2.40
+    - graph-tool >=2.40
   run:
     - python >=3.8 
-    - graph-tool-base >=2.40
+    - graph-tool >=2.40
     - scanpy
     - numpy
     - scipy


### PR DESCRIPTION
Apparently `graph-tool-base` as dependecy raises `cairo` imports that don't work. Dependencies have been updated to include `graph-tool`, which should automatically include cairo related stuff